### PR TITLE
feat: display post author in Card component

### DIFF
--- a/app/components/features/post/Card.vue
+++ b/app/components/features/post/Card.vue
@@ -48,6 +48,10 @@
       >
         <div class="flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
           <div class="flex items-center gap-2">
+            <UIcon name="i-lucide-user" class="w-4 h-4" />
+            <span>{{ post.author?.name || 'Auteur inconnu' }}</span>
+          </div>
+          <div class="flex items-center gap-2">
             <UIcon name="i-lucide-calendar" class="w-4 h-4" />
             <span>{{ formatDate(post.createdAt) }}</span>
           </div>


### PR DESCRIPTION
## Summary
- Add author name with user icon in Card.vue footer
- Show author information alongside creation and modification dates  
- Complete step 6 of authentication integration user story

## Changes
- Display post author name with `i-lucide-user` icon in Card component
- Author info shows before creation date in the footer metadata section
- Fallback to "Auteur inconnu" if author information is missing

## Test plan
- [x] Verify author name appears in post cards
- [x] Check user icon displays correctly
- [x] Confirm layout remains clean with author, creation, and modification dates
- [x] Test fallback text when author is missing

Closes #69

🤖 Generated with [Claude Code](https://claude.ai/code)