### PR TITLE
feat: migrate from auto-increment IDs to UUIDs

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,7 +3,10 @@
     "context7": {
       "type": "http",
       "url": "https://mcp.context7.com/mcp",
-      "alwaysAllow": ["resolve-library-id", "get-library-docs"]
+      "alwaysAllow": [
+        "resolve-library-id",
+        "get-library-docs"
+      ]
     },
     "nuxt": {
       "type": "sse",
@@ -28,7 +31,9 @@
     },
     "playwright": {
       "command": "npx",
-      "args": ["@playwright/mcp@latest"],
+      "args": [
+        "@playwright/mcp@latest"
+      ],
       "alwaysAllow": [
         "browser_navigate",
         "browser_snapshot",
@@ -40,8 +45,13 @@
     },
     "sequential-thinking": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"],
-      "alwaysAllow": ["sequentialthinking"]
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-sequential-thinking"
+      ],
+      "alwaysAllow": [
+        "sequentialthinking"
+      ]
     },
     "nuxt-docs": {
       "type": "sse",

--- a/prisma/migrations/20250802092207_init/migration.sql
+++ b/prisma/migrations/20250802092207_init/migration.sql
@@ -1,6 +1,9 @@
+-- CreateExtension
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
 -- CreateTable
 CREATE TABLE "public"."User" (
-    "id" SERIAL NOT NULL,
+    "id" TEXT NOT NULL DEFAULT uuid_generate_v4(),
     "email" TEXT NOT NULL,
     "password" TEXT NOT NULL,
     "name" TEXT NOT NULL,
@@ -12,10 +15,10 @@ CREATE TABLE "public"."User" (
 
 -- CreateTable
 CREATE TABLE "public"."Post" (
-    "id" SERIAL NOT NULL,
+    "id" TEXT NOT NULL DEFAULT uuid_generate_v4(),
     "title" TEXT NOT NULL,
     "content" TEXT,
-    "authorId" INTEGER NOT NULL,
+    "authorId" TEXT NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,12 +7,13 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("NUXT_DATABASE_URL")
+  provider   = "postgresql"
+  url        = env("NUXT_DATABASE_URL")
+  extensions = [uuid_ossp(map: "uuid-ossp")]
 }
 
 model User {
-  id        Int      @id @default(autoincrement())
+  id        String   @id @default(uuid())
   email     String   @unique
   password  String
   name      String
@@ -24,10 +25,10 @@ model User {
 }
 
 model Post {
-  id        Int      @id @default(autoincrement())
+  id        String   @id @default(uuid())
   title     String
   content   String?
-  authorId  Int
+  authorId  String
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   

--- a/server/api/posts/[id].delete.ts
+++ b/server/api/posts/[id].delete.ts
@@ -11,7 +11,8 @@
  *         in: path
  *         required: true
  *         schema:
- *           type: integer
+ *           type: string
+ *           format: uuid
  *     responses:
  *       200:
  *         description: Post deleted successfully

--- a/server/api/posts/[id].put.ts
+++ b/server/api/posts/[id].put.ts
@@ -11,7 +11,8 @@
  *         in: path
  *         required: true
  *         schema:
- *           type: integer
+ *           type: string
+ *           format: uuid
  *     requestBody:
  *       required: true
  *       content:

--- a/server/services/post.service.ts
+++ b/server/services/post.service.ts
@@ -10,7 +10,7 @@ import prisma from '@@/lib/prisma'
  */
 export async function createPost(
   postData: CreatePostData,
-  authorId: number
+  authorId: string
 ): Promise<PostWithAuthor> {
   try {
     const post = await prisma.post.create({
@@ -66,7 +66,7 @@ export async function getAllPosts(): Promise<PostWithAuthor[]> {
 /**
  * Get post by ID
  */
-export async function getPostById(id: number): Promise<PostWithAuthor | null> {
+export async function getPostById(id: string): Promise<PostWithAuthor | null> {
   const post = await prisma.post.findUnique({
     where: { id },
     include: {
@@ -90,9 +90,9 @@ export async function getPostById(id: number): Promise<PostWithAuthor | null> {
  * Update post if user owns it
  */
 export async function updatePost(
-  id: number,
+  id: string,
   postData: UpdatePostData,
-  authorId: number
+  authorId: string
 ): Promise<PostWithAuthor> {
   // Check if post exists and user owns it
   const existingPost = await prisma.post.findUnique({
@@ -146,7 +146,7 @@ export async function updatePost(
 /**
  * Delete post if user owns it
  */
-export async function deletePost(id: number, authorId: number): Promise<void> {
+export async function deletePost(id: string, authorId: string): Promise<void> {
   // Check if post exists and user owns it
   const existingPost = await prisma.post.findUnique({
     where: { id },

--- a/server/services/user.service.ts
+++ b/server/services/user.service.ts
@@ -78,7 +78,7 @@ export async function authenticateUser(email: string, password: string): Promise
 /**
  * Get user by ID
  */
-export async function getUserById(id: number): Promise<PublicUser | null> {
+export async function getUserById(id: string): Promise<PublicUser | null> {
   const user = await prisma.user.findUnique({
     where: { id }
   })
@@ -89,7 +89,7 @@ export async function getUserById(id: number): Promise<PublicUser | null> {
 /**
  * Check if user owns a specific post
  */
-export async function userOwnsPost(userId: number, postId: number): Promise<boolean> {
+export async function userOwnsPost(userId: string, postId: string): Promise<boolean> {
   const post = await prisma.post.findUnique({
     where: { id: postId },
     select: { authorId: true }

--- a/shared/models/post.ts
+++ b/shared/models/post.ts
@@ -15,10 +15,10 @@ import { z } from 'zod'
  * Complete Post entity (matches database schema)
  */
 export interface Post {
-  id: number
+  id: string
   title: string
   content: string | null
-  authorId: number
+  authorId: string
   createdAt: string
   updatedAt: string
 }
@@ -52,7 +52,7 @@ export const createPostSchema = z.object({
  * Schema for creating a new post (server-side with authorId)
  */
 export const createPostWithAuthorSchema = createPostSchema.extend({
-  authorId: z.number().int().positive()
+  authorId: z.string().uuid()
 })
 
 /**

--- a/shared/models/user.ts
+++ b/shared/models/user.ts
@@ -15,7 +15,7 @@ import { z } from 'zod'
  * Complete User entity (matches database schema)
  */
 export interface User {
-  id: number
+  id: string
   email: string
   password: string
   name: string
@@ -27,7 +27,7 @@ export interface User {
  * Public User entity (without sensitive fields)
  */
 export interface PublicUser {
-  id: number
+  id: string
   email: string
   name: string
   createdAt: string
@@ -199,7 +199,7 @@ export const initialPasswordState: PasswordFormState = {
  * Helper function to convert Prisma User to PublicUser
  */
 export function toPublicUser(user: {
-  id: number
+  id: string
   email: string
   password: string
   name: string

--- a/shared/schemas/common.schema.ts
+++ b/shared/schemas/common.schema.ts
@@ -5,10 +5,10 @@ import { z } from 'zod'
  */
 
 /**
- * Schema for validating numeric IDs (positive integers)
+ * Schema for validating UUID IDs
  */
 export const idSchema = z.object({
-  id: z.coerce.number().int().positive()
+  id: z.uuid()
 })
 
 /**


### PR DESCRIPTION
## Summary

Migration complète des IDs incrémentaux vers des UUIDs pour améliorer la sécurité et la scalabilité.

## Changes

### 🗄️ Database & Schema
- ✅ Modifié le schéma Prisma pour utiliser `String @id @default(uuid())`
- ✅ Ajouté l'extension `uuid-ossp` à PostgreSQL  
- ✅ Écrasé la migration initiale avec les nouveaux UUIDs

### 🔧 Backend
- ✅ Mis à jour tous les types et interfaces (`User`, `Post`, `PublicUser`)
- ✅ Modifié les schémas de validation Zod pour accepter les UUIDs
- ✅ Adapté tous les services backend (`user.service.ts`, `post.service.ts`)
- ✅ Mis à jour la documentation OpenAPI des routes

### ⚡ Performance & Tests
- ✅ Build successful sans erreurs TypeScript
- ✅ Serveur de développement démarré correctement
- ✅ API répond avec les bonnes validations d'erreur

## Breaking Changes
- **API**: Les IDs sont maintenant des strings UUID au lieu de numbers
- **Database**: Nouvelle structure avec UUIDs, les données existantes sont perdues

## Test plan
- [x] Build compile sans erreurs TypeScript
- [x] Serveur démarre sans erreurs
- [x] Base de données migrée vers les UUIDs
- [x] Routes API acceptent les UUIDs dans les paramètres

## Security Benefits
- Prévient l'énumération d'IDs
- Masque le volume de données métier
- Améliore la sécurité des APIs publiques

Closes #113

🤖 Generated with [Claude Code](https://claude.ai/code)